### PR TITLE
fix(issuer): disable corepack and use node directly in runtime stage

### DIFF
--- a/apps/issuer/Dockerfile
+++ b/apps/issuer/Dockerfile
@@ -21,10 +21,11 @@ RUN pnpm run -r build
 # RUN pnpm deploy --filter=issuer --prod /prod/issuer
 
 FROM base AS issuer
+RUN corepack disable
 # node_modules are symlinked to root directory, so we just copy the whole thing for now
 COPY --from=build /workspace /workspace
 # COPY --from=build /prod/issuer /prod/issuer
 WORKDIR /workspace/apps/issuer
 EXPOSE 8080 9090
-CMD [ "pnpm", "start" ]
+CMD [ "node", "dist/common/server.cjs" ]
 # docker build . --target issuer --tag issuer:latest


### PR DESCRIPTION
## Summary
- Disable corepack in the runtime Docker stage
- Use `node dist/common/server.cjs` directly instead of `pnpm start`

## Why
Corepack tries to write to `/.cache/node/corepack/` at startup. This fails when running with `readOnlyRootFilesystem: true` or as a non-root user in Kubernetes (`runAsUser: 65532`).

Since `pnpm start` just runs `node dist/common/server.cjs`, we can call node directly and avoid the corepack dependency at runtime entirely.

## Test
Built and tested locally:
```
docker build -f apps/issuer/Dockerfile --target issuer -t issuer:test .
docker run --rm --user 65532:65532 --read-only --tmpfs /tmp issuer:test
```
Starts without permission errors (crashes on missing env vars as expected).